### PR TITLE
Update to Realtek RTL8125 vendor driver version 9.012.03

### DIFF
--- a/SOURCES/0001-config_change.patch
+++ b/SOURCES/0001-config_change.patch
@@ -4,14 +4,17 @@
 ### Enable RSS option for better performance
 ### Enable automatic firmware loading, if optional firmware is available
 ### Enable WOL magic packet by default
+### Disable EEE to improve compatibility
 
---- a/src/Makefile	2022-10-02 02:41:33.318007620 +0000
-+++ b/src/Makefile	2022-10-02 02:42:18.302129039 +0000
-@@ -39,14 +39,14 @@
+--- a/src/Makefile	2023-11-01 17:53:04.552574114 +0000
++++ b/src/Makefile	2023-11-01 17:54:05.475797052 +0000
+@@ -38,15 +38,15 @@
+ CONFIG_ASPM = y
  ENABLE_S5WOL = y
  ENABLE_S5_KEEP_CURR_MAC = n
- ENABLE_EEE = y
+-ENABLE_EEE = y
 -ENABLE_S0_MAGIC_PACKET = n
++ENABLE_EEE = n
 +ENABLE_S0_MAGIC_PACKET = y
  ENABLE_TX_NO_CLOSE = y
 -ENABLE_MULTIPLE_TX_QUEUE = n
@@ -25,6 +28,6 @@
  ENABLE_LIB_SUPPORT = n
 -ENABLE_USE_FIRMWARE_FILE = n
 +ENABLE_USE_FIRMWARE_FILE = y
- DISABLE_PM_SUPPORT = n
+ DISABLE_WOL_SUPPORT = n
  DISABLE_MULTI_MSIX_VECTOR = n
- 
+ ENABLE_DOUBLE_VLAN = n

--- a/SOURCES/r8125-9.010.01.tar.gz
+++ b/SOURCES/r8125-9.010.01.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33445408ff077f1135ccb63b90a99328e5231795e0558b510f52a38e9b7c4b68
-size 117459

--- a/SOURCES/r8125-9.012.03.tar.gz
+++ b/SOURCES/r8125-9.012.03.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b808ce9b80a30a7dd589bc2fcb7070649cbbff1ad97cebd35f1d3ce6eba2bbc
+size 144962

--- a/SPECS/r8125-module.spec
+++ b/SPECS/r8125-module.spec
@@ -8,7 +8,7 @@
 
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{driver_name}-module
-Version: 9.010.01
+Version: 9.012.03
 Release: 1%{?dist}
 License: GPL
 
@@ -56,6 +56,9 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 /lib/modules/%{kernel_version}/*/*.ko
 
 %changelog
+* Wed Nov 01 2023 Andrew Lindh <andrew@netplex.net> - 9.012.03-1
+- Update driver to new vendor version
+
 * Fri Nov 04 2022 Andrew Lindh <andrew@netplex.net> - 9.010-01-1
 - Update driver to new version and options
 


### PR DESCRIPTION
No change log from vendor. Basic RSS now supported. Untestable support for new RTL8126 chipset.