### PR TITLE
Disable TXchecksum/SG/TSO to work around Realtek bugs

### DIFF
--- a/SOURCES/0003-txcsum_sg_tso_off.patch
+++ b/SOURCES/0003-txcsum_sg_tso_off.patch
@@ -1,0 +1,42 @@
+###
+### Disable TX Checksum and TSO by default due to problem
+### with Windows Server VMs
+###
+--- a/src/r8125_n.c	2024-02-01 02:24:36.095565118 +0000
++++ b/src/r8125_n.c	2024-02-01 02:28:23.183256238 +0000
+@@ -17339,8 +17339,9 @@
+          * enable them. Use at own risk!
+          */
+         tp->cp_cmd |= RTL_R16(tp, CPlusCmd);
++	dev->features &= ~(NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM | NETIF_F_SG);
++	dev->features &= ~NETIF_F_ALL_TSO;
+         if (tp->mcfg != CFG_METHOD_DEFAULT) {
+-                dev->features |= NETIF_F_IP_CSUM;
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(3,0,0)
+                 tp->cp_cmd |= RxChkSum;
+ #else
+@@ -17352,7 +17353,7 @@
+                         /* nothing to do */
+                         break;
+                 default:
+-                        dev->features |= NETIF_F_SG | NETIF_F_TSO;
++                        /* do not enable SG and TSO */
+                         break;
+                 };
+                 dev->hw_features = NETIF_F_SG | NETIF_F_IP_CSUM | NETIF_F_TSO |
+@@ -17366,7 +17367,6 @@
+                 dev->hw_features |= NETIF_F_RXFCS;
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,22)
+                 dev->hw_features |= NETIF_F_IPV6_CSUM | NETIF_F_TSO6;
+-                dev->features |= NETIF_F_IPV6_CSUM;
+                 switch (tp->mcfg) {
+                 case CFG_METHOD_2:
+                 case CFG_METHOD_3:
+@@ -17374,7 +17374,6 @@
+                         /* nothing to do */
+                         break;
+                 default:
+-                        dev->features |= NETIF_F_TSO6;
+                         break;
+                 };
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)

--- a/SPECS/r8125-module.spec
+++ b/SPECS/r8125-module.spec
@@ -9,7 +9,7 @@
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{driver_name}-module
 Version: 9.012.04
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPL
 
 #Source taken from https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software
@@ -17,6 +17,7 @@ Source0: %{driver_name}-%{version}.tar.gz
 
 Patch0: 0001-config_change.patch
 Patch1: 0002-use_new_api.patch
+Patch2: 0003-txcsum_sg_tso_off.patch
 
 BuildRequires: gcc
 BuildRequires: kernel-devel
@@ -56,6 +57,9 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 /lib/modules/%{kernel_version}/*/*.ko
 
 %changelog
+* Wed Jan 31 2024 Andrew Lindh <andrew@netplex.net> - 9.012.04-2
+- Disable driver txchecksum/sg/tso by default to workaround bugs
+
 * Wed Jan 10 2024 Andrew Lindh <andrew@netplex.net> - 9.012.04-1
 - Update driver to new vendor version, minor HW version fix for irq_nvecs
 


### PR DESCRIPTION
Disable TXchecksum/SG/TSO to work around Realtek bugs. Some cards have this disabled by default already, some don't.
This disables the performance features by default for all. Can be re-enabled using ```ethtool -K eth0 tx on tso on sg on```
Realtek does not issue release notes or respond to emails...

Fixes Windows Server 2022 guest network data errors.
Issue reported by [glenlewis09](https://xcp-ng.org/forum/user/glenlewis09) on [forum post](https://xcp-ng.org/forum/topic/8289)

